### PR TITLE
Solve documentDB exceeded maximum query length problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "joi": "^10.6.0",
     "karma": "^1.1.0",
     "karma-mocha": "^1.1.1",
+    "lodash": "^4.17.4",
     "memory-cache": "^0.1.6",
     "merge": "^1.2.0",
     "mongoose": "^4.5.2",


### PR DESCRIPTION
When a github account has thousands of repos, the query to get linked repos tends to be very big. When the query is big, the DocuemntDB will send an error with a message, 'The SQL query text exceeded the maximum limit of 30720 characters'. Chunk big query to small queries.