### PR TITLE
Should not use cache

### DIFF
--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -317,6 +317,7 @@ module.exports = function () {
                 repo: repo,
                 owner: owner,
                 number: number,
+                noCache: true
             },
             token: token
         }).then(function (resp) {

--- a/src/tests/server/services/cla.js
+++ b/src/tests/server/services/cla.js
@@ -109,6 +109,7 @@ function stub() {
                 return Promise.resolve(testRes.gistData);
             }
         } else if (args.obj === 'pullRequests' && args.fun === 'getFiles') {
+            assert(args.arg.noCache);
             return Promise.resolve(testRes.pullRequestFiles);
         }
     });


### PR DESCRIPTION
When a contributor changes a pull request very frequently, caching cause problem.
Say he makes the PR big and then makes it small immediately, the CLA-Assistant will use the cached big PR and determine a CLA is required. 
So we should not use cache when determine whether a PR is big or not.