### PR TITLE
When pull request cache is big, query should put sort property.

### DIFF
--- a/src/server/services/pullRequestStore.js
+++ b/src/server/services/pullRequestStore.js
@@ -47,6 +47,12 @@ module.exports = {
     },
 
     findPullRequests: function (query, done) {
-        PullRequest.find(query, done);
+        PullRequest.find(query, {}, {
+            sort: {
+                userId: 1,
+                repoId: 1,
+                number: 1
+            }
+        }, done);
     }
 };

--- a/src/tests/server/services/pullRequestStore.js
+++ b/src/tests/server/services/pullRequestStore.js
@@ -142,7 +142,7 @@ describe('pullRequestStore', function () {
         var query = null;
         beforeEach(function () {
             query = {};
-            sinon.stub(PullRequest, 'find', function (query, done) {
+            sinon.stub(PullRequest, 'find', function (query, selection, options, done) {
                 done();
             });
         });


### PR DESCRIPTION
Otherwise, it will send "cursor does not exist, was killed or timed out" error.