### PR TITLE
Bugfix: recheck api

### DIFF
--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -331,7 +331,6 @@ module.exports = {
     // sha (optional)
     // token (optional)
     validatePullRequest: function (args, done) {
-        args.token = args.token ? args.token : token;
         cla.getLinkedItem(args, function (error, item) {
             if (error) {
                 return log.error(error);
@@ -345,6 +344,7 @@ module.exports = {
                     }, done);
                 });
             }
+            args.token = args.token || item.token;
             cla.isClaRequired(args, function (error, isClaRequired) {
                 if (error) {
                     return log.error(error);


### PR DESCRIPTION
When rechecking the status of a pull request using API: 

host/:owner/:repo?pullRequest=1

it may fail because the token is null.