### PR TITLE
Reduce github call:

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "github": "^7.0.1",
     "glob": "^7.0.5",
     "joi": "^10.6.0",
+    "json-stable-stringify": "^1.0.1",
     "karma": "^1.1.0",
     "karma-mocha": "^1.1.1",
     "lodash": "^4.17.4",

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -176,7 +176,7 @@ module.exports = function () {
         return newQuery;
     };
 
-    var getPR = function (owner, repo, number, token) {
+    var getPR = function (owner, repo, number, token, noCache) {
         var deferred = q.defer();
         github.call({
             obj: 'pullRequests',
@@ -184,7 +184,8 @@ module.exports = function () {
             arg: {
                 owner: owner,
                 repo: repo,
-                number: number
+                number: number,
+                noCache: noCache
             },
             token: token
         }, function (error, pullRequest) {
@@ -333,16 +334,13 @@ module.exports = function () {
             if (typeof item.minFileChanges !== 'number' && typeof item.minCodeChanges !== 'number') {
                 return true;
             }
-            return getPullRequestFiles(repo, owner, number, token).then(function (files) {
-                if (typeof item.minFileChanges === 'number' && files.length >= item.minFileChanges) {
+            var noCache = true;
+            return getPR(owner, repo, number, token, noCache).then(function (pullRequest) {
+                if (typeof item.minFileChanges === 'number' && pullRequest.changed_files >= item.minFileChanges) {
                     return true;
                 }
-                if (typeof item.minCodeChanges === 'number') {
-                    var sum = 0;
-                    return files.some(function (file) {
-                        sum += file.changes;
-                        return sum >= item.minCodeChanges;
-                    });
+                if (typeof item.minCodeChanges === 'number' && pullRequest.additions + pullRequest.deletions >= item.minCodeChanges) {
+                    return true;
                 }
                 return false;
             });

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -4,6 +4,7 @@ var cache = require('memory-cache');
 var config = require('../../config');
 var GitHubApi = require('github');
 var logger = require('./logger');
+var stringify = require('json-stable-stringify');
 
 // var githubApi;
 
@@ -68,10 +69,13 @@ var githubService = {
         var obj = call.obj;
         var token = call.token;
 
-        var stringArgs = JSON.stringify({
+        var argWithoutNoCache = Object.assign({}, arg);
+        delete argWithoutNoCache.noCache;
+
+        var stringArgs = stringify({
             obj: call.obj,
             fun: call.fun,
-            arg: call.arg,
+            arg: argWithoutNoCache,
             token: call.token
         });
         var github = newGithubApi();

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -104,32 +104,21 @@ module.exports = function (req, res) {
 
 
         setTimeout(function () {
-            repoService.get(args, function (e, repo) {
-                if (repo) {
-                    if (!repo.gist) {
-                        return;
-                    }
-                    args.orgId = undefined;
-                    args.token = repo.token;
-                    args.gist = repo.gist; //TODO: Test it!!
-                    handleWebHook(args);
-                } else {
-                    orgService.get({
-                        orgId: args.orgId
-                    }, function (err, org) {
-                        if (org) {
-                            args.token = org.token;
-                            args.gist = org.gist; //TODO: Test it!!
-                            if (!org.isRepoExcluded(args.repo)) {
-                                repoService.getGHRepo(args, function (err, repo) {
-                                    if (repo) {
-                                        handleWebHook(args);
-                                    }
-                                });
-                            }
-                        }
-                    });
+            cla.getLinkedItem(args, function (err, item) {
+                if (!item) {
+                    return;
                 }
+                var nullCla = !item.gist;
+                var isExcluded = item.orgId && item.isRepoExcluded && item.isRepoExcluded(args.repo);
+                if (nullCla || isExcluded) {
+                    return;
+                }
+                args.token = item.token;
+                args.gist = item.gist;
+                if (item.repoId) {
+                    args.orgId = undefined;
+                }
+                return handleWebHook(args);
             });
         }, config.server.github.enforceDelay);
     }

--- a/src/tests/server/services/cla.js
+++ b/src/tests/server/services/cla.js
@@ -108,9 +108,6 @@ function stub() {
             } else {
                 return Promise.resolve(testRes.gistData);
             }
-        } else if (args.obj === 'pullRequests' && args.fun === 'getFiles') {
-            assert(args.arg.noCache);
-            return Promise.resolve(testRes.pullRequestFiles);
         }
     });
 }
@@ -1250,16 +1247,7 @@ describe('cla:isClaRequired', function () {
             gist: 'url/gistId',
             token: 'abc'
         };
-        testRes.pullRequestFiles = [
-            {
-                filename: 'test1',
-                changes: 4,
-            },
-            {
-                filename: 'test2',
-                changes: 10,
-            }
-        ];
+        testRes.getPR = {};
     });
 
     afterEach(function () {
@@ -1275,14 +1263,8 @@ describe('cla:isClaRequired', function () {
     });
 
     it('should require a CLA when pull request exceed minimum file changes', function (it_done) {
+        testRes.getPR.changed_files = 2;
         testRes.repoServiceGet.minFileChanges = 2;
-        testRes.pullRequestFiles = {
-            data:[{
-                filename: 'test1'
-            }, {
-                filename: 'test2'
-            }]
-        };
         cla.isClaRequired(args, function (err, isClaRequired) {
             assert.ifError(err);
             assert(isClaRequired);
@@ -1292,15 +1274,9 @@ describe('cla:isClaRequired', function () {
 
     it('should require a CLA when pull request exceed minimum code changes', function (it_done) {
         testRes.repoServiceGet.minCodeChanges = 15;
-        testRes.pullRequestFiles = {
-            data: [{
-                filename: 'test1',
-                changes: 5
-            }, {
-                filename: 'test2',
-                changes: 10
-            }]
-        };
+        testRes.getPR.changed_files = 1;
+        testRes.getPR.additions = 10;
+        testRes.getPR.deletions = 5;
         cla.isClaRequired(args, function (err, isClaRequired) {
             assert.ifError(err);
             assert(isClaRequired);
@@ -1311,12 +1287,9 @@ describe('cla:isClaRequired', function () {
     it('should NOT require a CLA when pull request NOT exceed minimum file and code changes', function (it_done) {
         testRes.repoServiceGet.minFileChanges = 2;
         testRes.repoServiceGet.minCodeChanges = 15;
-        testRes.pullRequestFiles = {
-            data: [{
-                filename: 'test1',
-                changes: 14,
-            }]
-        };
+        testRes.getPR.changed_files = 1;
+        testRes.getPR.additions = 10;
+        testRes.getPR.deletions = 4;
         cla.isClaRequired(args, function (err, isClaRequired) {
             assert.ifError(err);
             assert(!isClaRequired);


### PR DESCRIPTION
1. Github response cache key is not stable for the same github call.
2. Delete getPullRequestFiles() function and use cached getPullRequest instead to get changes of a pull request.
3. Github response cache key should not include 'noCache' property.