### PR TITLE
Bugfixs:

### DIFF
--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -492,8 +492,9 @@ module.exports = {
                 if (validateErr) {
                     log.error(validateErr);
                 }
-                done(validateErr, signed);
             });
+            // Signing page will get a timeout error if waiting for validating pull requests.
+            done(null, signed);
         });
     },
 
@@ -564,8 +565,9 @@ module.exports = {
                     if (validateErr) {
                         log.error(validateErr);
                     }
-                    done(validateErr, signed);
                 });
+                // Add signature API will get a timeout error if waiting for validating pull requests.
+                done(null, signed);
             });
         });
     },
@@ -619,8 +621,9 @@ module.exports = {
                     if (validateErr) {
                         log.error(validateErr);
                     }
-                    done(validateErr, dbCla);
                 });
+                // Terminate signature API will get a timeout error if waiting for validating pull requests.
+                done(null, dbCla);
             });
         });
     },
@@ -668,7 +671,7 @@ module.exports = {
                 query.ownerId = item.orgId.toString();
             }
             if (!item.sharedGist && item.repoId) {
-                query.orgId = item.repoId.toString();
+                query.repoId = item.repoId.toString();
             }
             return prStore.findPullRequests(query, function (err, pullRequests) {
                 if (err) {

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -487,7 +487,6 @@ describe('', function () {
             cla_api.sign(req, function (err, res) {
                 assert(cla_api.validateRelatedPullRequests.called);
                 assert(log.error.calledWith(error.cla_api.validateRelatedPullRequests));
-                assert.equal(err, error.cla_api.validateRelatedPullRequests);
                 it_done();
             });
         });
@@ -1391,8 +1390,7 @@ describe('', function () {
 
         it('should log error when validate related pull requests failed', function (it_done) {
             error.cla_api.validateRelatedPullRequests = 'Validate pull request failed';
-            cla_api.addSignature(req, function (err) {
-                assert(err);
+            cla_api.addSignature(req, function () {
                 assert(cla.sign.called);
                 assert(cla_api.validateRelatedPullRequests.called);
                 assert(log.error.called);


### PR DESCRIPTION
1. The sign/addSignature/terminateSignature API wait for validating pull requests which cause retries and timeout.
2. Should use repoId instead of orgId when query pull request in cache.