### PR TITLE
User userId whenever possible

### DIFF
--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -226,6 +226,7 @@ module.exports = {
     getLastSignature: function (req, done) {
         var args = req.args;
         args.user = req.user.login;
+        args.userId = req.user.id;
         cla.getLastSignature(args, done);
     },
 
@@ -503,7 +504,8 @@ module.exports = {
             repo: req.args.repo,
             owner: req.args.owner,
             number: req.args.number,
-            user: req.user.login
+            user: req.user.login,
+            userId: req.user.id
         };
 
         cla.check(args, done);

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -565,6 +565,7 @@ describe('', function () {
                     repo: 'Hello-World',
                     owner: 'octocat',
                     user: 'user',
+                    userId: 3,
                     number: undefined
                 });
                 cb(null, true);


### PR DESCRIPTION
Because user login name tends to change from time to time, we'd better provide userid to in order to query a user's signature.