### PR TITLE
Hide all token in app insights.

### DIFF
--- a/src/server/passports/token.js
+++ b/src/server/passports/token.js
@@ -32,7 +32,6 @@ function checkToken(accessToken, cb) {
     };
 
     github.call(args, function (err, data) {
-        logger.info('err: ', err, ' data: ', data);
         if (err || (data && data.scopes && data.scopes.indexOf('write:repo_hook') < 0) || !data) {
             err = err || 'You have not enough rights to call this API';
         }

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -51,6 +51,7 @@ module.exports = function () {
                 } catch (e) {
                     logger.warn(new Error(e).stack);
                 }
+                logger.info({ name: 'CLAAssistantGithubCall', path: path, token: token ? token.slice(0, 4) + '***' : '', remaining: res && res.headers ? res.headers['x-ratelimit-remaining'] : '' });
                 deferred.resolve(data);
             });
         });

--- a/src/server/services/logger.js
+++ b/src/server/services/logger.js
@@ -26,6 +26,7 @@ log = bunyan.createLogger({
 if (config.server.appInsights) {
     appInsights.setup(config.server.appInsights)
         .setAutoCollectConsole(true)
+        .setAutoCollectDependencies(false)
         .start();
 }
 


### PR DESCRIPTION
Stop using application insight auto-collect http request as dependencies. Explicitly log github calls.