### PR TITLE
Bugfix: should call done() when getLinkedItem fail

### DIFF
--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -334,7 +334,10 @@ module.exports = {
     validatePullRequest: function (args, done) {
         cla.getLinkedItem(args, function (error, item) {
             if (error) {
-                return log.error(error);
+                var logArgs = Object.assign({}, args);
+                logArgs.token = logArgs.token ? logArgs.token.slice(0, 4) + '***' : undefined;
+                log.error(error, logArgs);
+                return done();
             }
             args.token = args.token || item.token;
             if (!item.gist) {


### PR DESCRIPTION
When a user signs a CLA, the CLA-Assistant will sequentially validate all pull request related to the user. Without calling done() or call with done(error) will stop the other pull request validation. So we need to log error and call done() here.

Related code: https://github.com/Microsoft/cla-assistant/blob/miczeng/bugfix/src/server/api/cla.js#L413