### PR TITLE
Bugfix: enlarge the body parser limitation.

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -37,7 +37,7 @@ app.use(function (req, res, next) {
 });
 
 app.use(require('x-frame-options')());
-app.use(require('body-parser').json({ limit: '1mb' }));
+app.use(require('body-parser').json({ limit: '5mb' }));
 app.use(require('cookie-parser')());
 app.use(require('cookie-session')({
     secret: config.server.security.sessionSecret,

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -37,7 +37,7 @@ app.use(function (req, res, next) {
 });
 
 app.use(require('x-frame-options')());
-app.use(require('body-parser').json());
+app.use(require('body-parser').json({ limit: '1mb' }));
 app.use(require('cookie-parser')());
 app.use(require('cookie-session')({
     secret: config.server.security.sessionSecret,


### PR DESCRIPTION
When body parser parse the web hook event payload. It throw the error bellow.

PayloadTooLargeError: request entity too large
    at readStream (/cla-assistant/node_modules/raw-body/index.js:155:17)
    at getRawBody (/cla-assistant/node_modules/raw-body/index.js:108:12)
    at read (/cla-assistant/node_modules/body-parser/lib/read.js:77:3)
    at jsonParser (/cla-assistant/node_modules/body-parser/lib/types/json.js:134:5)
    at Layer.handle [as handle_request] (/cla-assistant/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/cla-assistant/node_modules/express/lib/router/index.js:317:13)
    at /cla-assistant/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/cla-assistant/node_modules/express/lib/router/index.js:335:12)
    at next (/cla-assistant/node_modules/express/lib/router/index.js:275:10)
    at /cla-assistant/node_modules/x-frame-options/index.js:6:5
    at Layer.handle [as handle_request] (/cla-assistant/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/cla-assistant/node_modules/express/lib/router/index.js:317:13)
    at /cla-assistant/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/cla-assistant/node_modules/express/lib/router/index.js:335:12)
    at next (/cla-assistant/node_modules/express/lib/router/index.js:275:10)
    at /cla-assistant/src/server/app.js:29:9
    at Layer.handle [as handle_request] (/cla-assistant/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/cla-assistant/node_modules/express/lib/router/index.js:317:13)
    at /cla-assistant/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/cla-assistant/node_modules/express/lib/router/index.js:335:12)
    at next (/cla-assistant/node_modules/express/lib/router/index.js:275:10)
    at expressInit (/cla-assistant/node_modules/express/lib/middleware/init.js:40:5)
    at Layer.handle [as handle_request] (/cla-assistant/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/cla-assistant/node_modules/express/lib/router/index.js:317:13)
    at /cla-assistant/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/cla-assistant/node_modules/express/lib/router/index.js:335:12)
    at next (/cla-assistant/node_modules/express/lib/router/index.js:275:10)
    at query (/cla-assistant/node_modules/express/lib/middleware/query.js:45:5)
    at Layer.handle [as handle_request] (/cla-assistant/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/cla-assistant/node_modules/express/lib/router/index.js:317:13)
    at /cla-assistant/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/cla-assistant/node_modules/express/lib/router/index.js:335:12)
    at next (/cla-assistant/node_modules/express/lib/router/index.js:275:10)
    at Function.handle (/cla-assistant/node_modules/express/lib/router/index.js:174:3)
    at EventEmitter.handle (/cla-assistant/node_modules/express/lib/application.js:174:10)
    at app (/cla-assistant/node_modules/express/lib/express.js:39:9)
    at /cla-assistant/node_modules/applicationinsights/out/AutoCollection/HttpRequests.js:76:25
    at ZoneDelegate.invoke (/cla-assistant/node_modules/zone.js/dist/zone-node.js:242:26)
    at Zone.run (/cla-assistant/node_modules/zone.js/dist/zone-node.js:113:43)
    at Function.CorrelationContextManager.runWithContext (/cla-assistant/node_modules/applicationinsights/out/AutoCollection/CorrelationContextManager.js:47:21)
    at Server.<anonymous> (/cla-assistant/node_modules/applicationinsights/out/AutoCollection/HttpRequests.js:65:71)
    at ZoneDelegate.invokeTask (/cla-assistant/node_modules/zone.js/dist/zone-node.js:275:35)
    at Zone.runTask (/cla-assistant/node_modules/zone.js/dist/zone-node.js:151:47)
    at Server.ZoneTask.invoke (/cla-assistant/node_modules/zone.js/dist/zone-node.js:345:33)
    at emitTwo (events.js:106:13)
    at Server.emit (events.js:191:7)
    at HTTPParser.parserOnIncoming [as onIncoming] (_http_server.js:546:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:99:23)