### PR TITLE
Disable index creation for 'clas' collection.

### DIFF
--- a/src/server/documents/cla.js
+++ b/src/server/documents/cla.js
@@ -31,13 +31,14 @@ var indexOptions = {
 
 var CLA = mongoose.model('CLA', CLASchema);
 
-CLA.collection.dropAllIndexes(function(err, results) {
-    if (err) {
-        logger.warn('CLA collection dropAllIndexes error: ', err);
-        logger.warn('dropAllIndexes results: ', results);
-    }
-});
-CLA.collection.createIndex(index, indexOptions);
+// TODO: Remove this for now because Document DB will create problematic index.
+// CLA.collection.dropAllIndexes(function(err, results) {
+//     if (err) {
+//         logger.warn('CLA collection dropAllIndexes error: ', err);
+//         logger.warn('dropAllIndexes results: ', results);
+//     }
+// });
+// CLA.collection.createIndex(index, indexOptions);
 
 module.exports = {
     CLA: CLA


### PR DESCRIPTION
The temporary solution avoids creating the problematic index of 'clas' collection.