### PR TITLE
Bugfix: CLA-Assistant doesn't update pull request status

### DIFF
--- a/.deploy/dev.yml
+++ b/.deploy/dev.yml
@@ -64,6 +64,8 @@ spec:
           value: 'submitter'
         - name: ENABLE_PRIVATE_REPOS
           value: 'true'
+        - name: GITHUB_DELAY
+          value: 7000
       imagePullSecrets:
         - name: ospok8sprod.azurecr.io
 ---

--- a/.deploy/prod.yml
+++ b/.deploy/prod.yml
@@ -64,6 +64,8 @@ spec:
           value: 'submitter'
         - name: ENABLE_PRIVATE_REPOS
           value: 'true'
+        - name: GITHUB_DELAY
+          value: 7000
       imagePullSecrets:
         - name: ospok8sprod.azurecr.io
 ---


### PR DESCRIPTION
In this case, when the pull request event received, the CLA-Assistant tried to update previous pull request commit instead of the latest commit. So the pull request status didn't keep updated. My guess is the Github eventual consistent policy. The simpliest way is to delay more time to process a pull request. (It seems that CLA-Assistant team has noticed the problem. So they provide a configuration setting.)