### PR TITLE
Bugfix: CLA-Assistant was not configured support private repos.

### DIFF
--- a/.deploy/dev.yml
+++ b/.deploy/dev.yml
@@ -56,10 +56,6 @@ spec:
           value: 'jeffmcaffer, willbar, jeffwilcox, geneh, notlaforge, arnom-ms, capfei, MichaelTsengLZ, MichaelTsengZL'
         - name: CLOSE_COMMENT
           value: 'true'
-        - name: ALWAYS_SHOW_UNSIGNED_LIST
-          value: 'true'
-        - name: CACHE_PULL_REQUESTS
-          value: 'true'
         - name: REQUIRED_SIGNEES
           value: 'submitter'
         - name: ENABLE_PRIVATE_REPOS

--- a/.deploy/prod.yml
+++ b/.deploy/prod.yml
@@ -56,10 +56,6 @@ spec:
           value: msftgits
         - name: CLOSE_COMMENT
           value: 'true'
-        - name: ALWAYS_SHOW_UNSIGNED_LIST
-          value: 'true'
-        - name: CACHE_PULL_REQUESTS
-          value: 'true'
         - name: REQUIRED_SIGNEES
           value: 'submitter'
         - name: ENABLE_PRIVATE_REPOS

--- a/src/config.js
+++ b/src/config.js
@@ -103,6 +103,8 @@ module.exports = {
         feature_flag: {
             pre_populate_user_pull_request: process.env.PRE_POPULATE_USER_PULL_REQUEST === 'true',
             required_signees: process.env.REQUIRED_SIGNEES || '',
+            close_comment: process.env.CLOSE_COMMENT,
+            enable_private_repos: process.env.ENABLE_PRIVATE_REPOS
         },
 
         static: [


### PR DESCRIPTION
When resolving rebase conflicts, the following changes are missing.
1. Set _ENABLE_PRIVATE_REPOS_ environment variable to 'true' to support private repos.
2. Remove unnecessary configuration settings: 
    a. ALWAYS_SHOW_UNSIGNED_LIST: Because submitter mode will only show the submitter signature status, we don't need this setting.
    b. CACHE_PULL_REQUESTS: Upstream master use pull request cache. So we can delete this setting.