### PR TITLE
Remove reference to Source Sans Pro font

### DIFF
--- a/src/client/login.html
+++ b/src/client/login.html
@@ -51,7 +51,6 @@
         <!-- COMPONENT STYLESHEETS -->
         <link href="/components-font-awesome/css/font-awesome.min.css" rel="stylesheet">
         <link href="/octicons/lib/octicons.css" rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600" rel="stylesheet" type="text/css">
         <!-- APP STYLESHEET -->
         <link href="/assets/styles/app.css" rel="stylesheet">
     </head>


### PR DESCRIPTION
Helps mitigate a simple issue by removing this specific font. If need be we can reference a different one later.