### PR TITLE
Use admin token to link orgs or repos

### DIFF
--- a/.deploy/dev.yml
+++ b/.deploy/dev.yml
@@ -52,6 +52,11 @@ spec:
             secretKeyRef:
               name: msftclas-app-insights-dev
               key: value
+        - name: GITHUB_ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-msftgits-super-token
+              key: value
         - name: GITHUB_ADMIN_USERS
           value: 'jeffmcaffer, willbar, jeffwilcox, geneh, notlaforge, arnom-ms, capfei, MichaelTsengLZ, MichaelTsengZL'
         - name: CLOSE_COMMENT

--- a/.deploy/prod.yml
+++ b/.deploy/prod.yml
@@ -55,7 +55,7 @@ spec:
         - name: GITHUB_ADMIN_TOKEN
           valueFrom:
             secretKeyRef:
-              name: github-msftgits-supper-token
+              name: github-msftgits-super-token
               key: value
         - name: GITHUB_ADMIN_USERS
           value: msftgits

--- a/.deploy/prod.yml
+++ b/.deploy/prod.yml
@@ -52,6 +52,11 @@ spec:
             secretKeyRef:
               name: msftclas-app-insights-prod
               key: value
+        - name: GITHUB_ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-msftgits-supper-token
+              key: value
         - name: GITHUB_ADMIN_USERS
           value: msftgits
         - name: CLOSE_COMMENT

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ module.exports = {
             api: process.env.GITHUB_API_HOST || 'api.github.com',
             enterprise: !!process.env.GITHUB_HOST, // flag enterprise version
             version: process.env.GITHUB_VERSION || '3.0.0',
+            adminToken: process.env.GITHUB_ADMIN_TOKEN,
 
             graphqlEndpoint: process.env.GITHUB_GRAPHQL || 'https://api.github.com/graphql',
 

--- a/src/config.js
+++ b/src/config.js
@@ -57,7 +57,8 @@ module.exports = {
 
         security: {
             sessionSecret: process.env.SESSION_SECRET || 'cla-assistant',
-            cookieMaxAge: 60 * 60 * 1000
+            cookieMaxAge: 60 * 60 * 1000,
+            cookieSecurity: !(process.env.NODE_ENV === 'localhost')
         },
 
         smtp: {

--- a/src/server/api/org.js
+++ b/src/server/api/org.js
@@ -13,7 +13,6 @@ module.exports = {
     //     org.check(req.args, done);
     // },
     create: function (req, done) {
-        req.args.token = req.args.token || req.user.token;
         let schema = Joi.object().keys({
             orgId: Joi.number().required(),
             org: Joi.string().required(),
@@ -24,6 +23,11 @@ module.exports = {
             minFileChanges: Joi.number(),
             minCodeChanges: Joi.number()
         });
+        req.args.token = req.args.token || req.user.token;
+        if (config.server.github.adminToken) {
+            req.args.token = config.server.github.adminToken;
+            delete schema.token;
+        }
         Joi.validate(req.args, schema, { abortEarly: false, allowUnknown: true }, function (joiError) {
             if (joiError) {
                 joiError.code = 400;

--- a/src/server/api/repo.js
+++ b/src/server/api/repo.js
@@ -10,7 +10,6 @@ module.exports = {
         repo.check(req.args, done);
     },
     create: function (req, done) {
-        req.args.token = req.args.token || req.user.token;
         let schema = Joi.object().keys({
             owner: Joi.string().required(),
             repo: Joi.string().required(),
@@ -21,6 +20,11 @@ module.exports = {
             minFileChanges: Joi.number(),
             minCodeChanges: Joi.number()
         });
+        req.args.token = req.args.token || req.user.token;
+        if (config.server.github.adminToken) {
+            req.args.token = config.server.github.adminToken;
+            delete schema.token;
+        }
         Joi.validate(req.args, schema, { abortEarly: false, allowUnknown: true }, function (joiError) {
             if (joiError) {
                 joiError.code = 400;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -154,7 +154,7 @@ async.series([
             saveUninitialized: true,
             resave: false,
             cookie: {
-                secure: true,
+                secure: config.server.security.cookieSecurity,
                 maxAge: config.server.security.cookieMaxAge
             },
             store: new MongoStore({

--- a/src/server/passports/github.js
+++ b/src/server/passports/github.js
@@ -89,6 +89,9 @@ passport.use(new Strategy({
                 token: accessToken
             }, function (err, res) {
                 if (res && res.length > 0) {
+                    if (config.server.github.adminToken) {
+                        return;
+                    }
                     res.forEach(function (repo) {
                         checkToken(repo, accessToken);
                     });
@@ -105,6 +108,9 @@ passport.use(new Strategy({
                 }
             }, function (err, res) {
                 if (res && res.length > 0) {
+                    if (config.server.github.adminToken) {
+                        return;
+                    }
                     res.forEach(function (org) {
                         checkToken(org, accessToken);
                     });


### PR DESCRIPTION
Using a specific token when linking an org or a repo instead of using the token of the admin who is currently logged in. 