### PR TITLE
Handle OAuth Error

### DIFF
--- a/src/client/assets/styles/_landing-page.scss
+++ b/src/client/assets/styles/_landing-page.scss
@@ -97,7 +97,7 @@ img.step-icon{
 // }
 //
 a.lp-signin:hover, a.lp-signin:focus {
-  color: $text-invert;
+  // color: $text-invert;
   cursor: pointer;
 }
 

--- a/src/client/templates/customField.html
+++ b/src/client/templates/customField.html
@@ -1,7 +1,8 @@
 <div ng-if="type != 'checkbox' && type != 'textarea' && !type.enum && type !== 'readonly'" title="{{description}}">
     <label ng-hide="type === 'hidden'" ng-class="{'required': required}">{{title || name}} </label>
     <div ng-show="description && type !== 'hidden'" class="description">({{description}})</div>
-    <input ng-disabled="!logged || signed" class="form-control" ng-model="value[name]" title="{{description}}" type="{{type}}"
+    <!-- TODO: Add 'type="{{type}}"' bace when CLA gist is able to change -->
+    <input ng-disabled="!logged || signed" class="form-control" ng-model="value[name]" title="{{description}}"
         min="{{min}}" max="{{max}}"></input>
 </div>
 <div ng-if="type == 'textarea'" title="{{description}}">


### PR DESCRIPTION
When passport fails on getting the user profile from GitHub, redirect the user to the login page.