### PR TITLE
Bugfixes

### DIFF
--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -477,6 +477,9 @@ module.exports = function () {
                 });
             } else if (args.number) {
                 return self.checkPullRequestSignatures(args, function (error, result) {
+                    if (error) {
+                        return done(error);
+                    }
                     done(error, result.signed, result.user_map);
                 });
             }

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -60,7 +60,7 @@ function updateStatusAndComment(args, done) {
             cla.check(args, function (error, signed, user_map) {
                 logger.trackEvent('CLAAssistantPullRequestClaCheckSuccess', { deliveryId: args.deliveryId });
                 if (error) {
-                    logger.warn(new Error(error).stack);
+                    return logger.error(new Error(error).stack);
                 }
                 args.signed = signed;
                 if (user_map && user_map.not_signed) {


### PR DESCRIPTION
When the Github returns a 502 error, the `result` will be `undefined`, which will cause another exception when calling `result.signed`.