### PR TITLE
Bugfix: this.logger is undefined

### DIFF
--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -319,7 +319,7 @@ module.exports = function () {
             }
             return false;
         } catch (e) {
-            this.logger.error(new Error(e).stack);
+            logger.error(new Error(e).stack);
 
             return true;
         }


### PR DESCRIPTION
`this.logger.error()` will throw exception.