### PR TITLE
Add an external queue (azure logic app) to save and redirect github events

### DIFF
--- a/.deploy/dev.yml
+++ b/.deploy/dev.yml
@@ -57,6 +57,11 @@ spec:
             secretKeyRef:
               name: github-msftgits-super-token-dev
               key: value
+        - name: EXTERNAL_QUEUE_URL
+          valueFrom:
+            secretKeyRef:
+              name: cla-web-hook-event-logic-app-dev
+              key: value
         - name: GITHUB_ADMIN_USERS
           value: 'jeffmcaffer, willbar, jeffwilcox, geneh, notlaforge, arnom-ms, capfei, MichaelTsengLZ, MichaelTsengZL'
         - name: CLOSE_COMMENT
@@ -70,6 +75,8 @@ spec:
         - name: PRE_POPULATE_USER_PULL_REQUEST
           value: 'true'
         - name: ALWAYS_SHOW_UNSIGNED_LIST
+          value: 'true'
+        - name: WAIT_FOR_WEB_HOOK_EVENT_PROCESS
           value: 'true'
       imagePullSecrets:
         - name: ospoaksdev.azurecr.io

--- a/.deploy/prod.yml
+++ b/.deploy/prod.yml
@@ -57,6 +57,11 @@ spec:
             secretKeyRef:
               name: github-msftgits-super-token
               key: value
+        - name: EXTERNAL_QUEUE_URL
+          valueFrom:
+            secretKeyRef:
+              name: cla-web-hook-event-logic-app-msft-prod
+              key: value
         - name: GITHUB_ADMIN_USERS
           value: msftgits
         - name: CLOSE_COMMENT
@@ -70,6 +75,8 @@ spec:
         - name: PRE_POPULATE_USER_PULL_REQUEST
           value: 'true'
         - name: ALWAYS_SHOW_UNSIGNED_LIST
+          value: 'true'
+        - name: WAIT_FOR_WEB_HOOK_EVENT_PROCESS
           value: 'true'
       imagePullSecrets:
         - name: ospoaksprod.azurecr.io

--- a/bower.json
+++ b/bower.json
@@ -1,28 +1,31 @@
 {
-    "name": "cla-assistant",
-    "version": "1.0.0",
-    "dependencies": {
-        "bootstrap-sass-official": "~3.2.0",
-        "angular": "1.7.0",
-        "angular-animate": "1.7.0",
-        "angular-route": "1.7.0",
-        "angular-ui-router": "1.0.22",
-        "angular-bootstrap": "0.13.4",
-        "angular-ui-select": "0.19.8",
-        "angular-ui-utils": "0.1.1",
-        "angular-sanitize": "1.7.0",
-        "angular-scroll": "0.6.5",
-        "ng-csv": "0.3.3",
-        "angulartics": "0.17.2",
-        "components-font-awesome": "4.1.0",
-        "papaparse": "4.1.2",
-        "clipboard": "1.5.5",
-        "selectize": "0.12.1",
-        "octicons": "6.0.1"
-    },
-    "devDependencies": {
-        "angular-mocks": "1.7.0",
-        "should": "^13.2.1",
-        "sinonjs": "^1.17.1"
-    }
+  "name": "cla-assistant",
+  "version": "1.0.0",
+  "dependencies": {
+    "bootstrap-sass-official": "~3.2.0",
+    "angular": "1.7.0",
+    "angular-animate": "1.7.0",
+    "angular-route": "1.7.0",
+    "angular-ui-router": "1.0.22",
+    "angular-bootstrap": "0.13.4",
+    "angular-ui-select": "0.19.8",
+    "angular-ui-utils": "0.1.1",
+    "angular-sanitize": "1.7.0",
+    "angular-scroll": "0.6.5",
+    "ng-csv": "0.3.3",
+    "angulartics": "0.17.2",
+    "components-font-awesome": "4.1.0",
+    "papaparse": "4.1.2",
+    "clipboard": "1.5.5",
+    "selectize": "0.12.1",
+    "octicons": "6.0.1"
+  },
+  "devDependencies": {
+    "angular-mocks": "1.7.0",
+    "should": "^13.2.1",
+    "sinonjs": "^1.17.1"
+  },
+  "resolutions": {
+    "angular": "1.7.8"
+  }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -112,7 +112,9 @@ module.exports = {
             organization_override_enabled: process.env.ORG_OVERRIDE_ENABLED || false,
             close_comment: process.env.CLOSE_COMMENT === 'true',
             enable_private_repos: process.env.ENABLE_PRIVATE_REPOS === 'true',
-            always_show_unsigned_list: process.env.ALWAYS_SHOW_UNSIGNED_LIST === 'true'
+            always_show_unsigned_list: process.env.ALWAYS_SHOW_UNSIGNED_LIST === 'true',
+            wait_for_web_hook_event_process: process.env.WAIT_FOR_WEB_HOOK_EVENT_PROCESS === 'true',
+            external_queue_url:process.env.EXTERNAL_QUEUE_URL,
         },
 
         static: [

--- a/src/server/services/url.js
+++ b/src/server/services/url.js
@@ -88,7 +88,7 @@ module.exports = function () {
             return checkUrl;
         },
         webhook: function (repo) {
-            return url.resolve(baseUrl, '/github/webhook/' + repo);
+            return config.server.feature_flag.external_queue_url || url.resolve(baseUrl, '/github/webhook/' + repo);
         }
     };
 }();


### PR DESCRIPTION
1. In order to solve abuse GitHub rate limit issue, we are trying to using an external queue so that we could serially process GitHub events.
2. When the CLA-Assistant is down, we could still store all the GitHub events and reprocess them in the future.