### PR TITLE
Skip error when the Github return 422 (Unprocessable Entity)

### DIFF
--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -442,7 +442,7 @@ module.exports = function () {
                     args.gist_version,
                     args.onDates
                 );
-                if (signed && user_map.includes(headOrg.login)) {
+                if (signed && user_map.signed.includes(headOrg.login)) {
                     return ({ signed, user_map });
                 }
             }

--- a/src/server/services/status.js
+++ b/src/server/services/status.js
@@ -75,6 +75,9 @@ let createStatus = function (args, context, description, state, target_url, done
             logger.warn('Error on Create Status, possible cause - wrong token, saved token does not have enough rights: ');
             log(error, response, { owner: args.owner, repo: args.repo, number: args.number, sha: args.sha, state });
         }
+        if (error.code === 422) {
+            error = null;
+        }
         if (typeof done === 'function') {
             done(error, response);
         }


### PR DESCRIPTION
When the source of a pull request has been deleted, Github still points the PR head to the deleted commit. Then we will get a 422 error when trying to create a status to the commit.