### PR TITLE
Bugfix: pullRequest.head.repo can be null

### DIFF
--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -427,7 +427,10 @@ module.exports = function () {
             }
             args.onDates.push(new Date(pullRequest.created_at));
 
-            const isOrgHead = pullRequest.head.repo.owner.type === 'Organization';
+            const isOrgHead = pullRequest.head
+                && pullRequest.head.repo
+                && pullRequest.head.repo.owner
+                && pullRequest.head.repo.owner.type === 'Organization';
             if (organizationOverrideEnabled && isOrgHead) {
                 const { owner: headOrg } = pullRequest.head.repo;
                 if (item.isUserWhitelisted !== undefined && item.isUserWhitelisted(headOrg.login)) {


### PR DESCRIPTION
The `pullRequest.head.repo` can be null. Check before use it.