### PR TITLE
Migrate to GitHub app

### DIFF
--- a/.deploy/dev.yml
+++ b/.deploy/dev.yml
@@ -66,6 +66,16 @@ spec:
             secretKeyRef:
               name: cla-web-hook-event-logic-app-dev
               key: value
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: cla-assistant-github-app-private-key-dev
+              key: appId
+        - name: GITHUB_APP_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: cla-assistant-github-app-private-key-dev
+              key: value
         - name: GITHUB_ADMIN_USERS
           value: 'jeffmcaffer, willbar, jeffwilcox, geneh, notlaforge, arnom-ms, capfei, MichaelTsengLZ, MichaelTsengZL'
         - name: CLOSE_COMMENT

--- a/package-lock.json
+++ b/package-lock.json
@@ -2190,12 +2190,12 @@
             "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
         },
         "dtrace-provider": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.5.tgz",
-            "integrity": "sha1-mOu6Ihr6xG4cOf02hY2Pk2dSS5I=",
+            "version": "0.8.8",
+            "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+            "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
             "optional": true,
             "requires": {
-                "nan": "^2.3.3"
+                "nan": "^2.14.0"
             }
         },
         "ecc-jsbn": {
@@ -6216,9 +6216,9 @@
             }
         },
         "moment": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-            "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8=",
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+            "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
             "optional": true
         },
         "mongodb": {
@@ -6361,9 +6361,9 @@
             }
         },
         "nan": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-            "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+            "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
             "optional": true
         },
         "nanomatch": {
@@ -7847,9 +7847,9 @@
             "dev": true
         },
         "safe-json-stringify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
-            "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+            "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
             "optional": true
         },
         "safe-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,104 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@octokit/app": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/app/-/app-4.2.0.tgz",
+            "integrity": "sha512-gPoVRQFhx/b5n2vc6p+FHOknXo3g2w38k3MxBfxxrULAN/XtIUllVe7h8f2J0Z4bMu0BGGcyWKyGd4T7w108mg==",
+            "requires": {
+                "@octokit/request": "^5.0.0",
+                "jsonwebtoken": "^8.3.0",
+                "lru-cache": "^5.1.1"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                }
+            }
+        },
+        "@octokit/endpoint": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.2.tgz",
+            "integrity": "sha512-xs1mmCEZ2y4shXCpFjNq3UbmNR+bLzxtZim2L0zfEtj9R6O6kc4qLDvYw66hvO6lUsYzPTM5hMkltbuNAbRAcQ==",
+            "requires": {
+                "@octokit/types": "^4.0.1",
+                "is-plain-object": "^3.0.0",
+                "universal-user-agent": "^5.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+                    "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+                    "requires": {
+                        "isobject": "^4.0.0"
+                    }
+                },
+                "isobject": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+                    "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+                }
+            }
+        },
+        "@octokit/request": {
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.4.tgz",
+            "integrity": "sha512-vqv1lz41c6VTxUvF9nM+a6U+vvP3vGk7drDpr0DVQg4zyqlOiKVrY17DLD6de5okj+YLHKcoqaUZTBtlNZ1BtQ==",
+            "requires": {
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.0.0",
+                "@octokit/types": "^4.0.1",
+                "deprecation": "^2.0.0",
+                "is-plain-object": "^3.0.0",
+                "node-fetch": "^2.3.0",
+                "once": "^1.4.0",
+                "universal-user-agent": "^5.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+                    "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+                    "requires": {
+                        "isobject": "^4.0.0"
+                    }
+                },
+                "isobject": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+                    "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+                }
+            }
+        },
+        "@octokit/request-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.1.tgz",
+            "integrity": "sha512-5lqBDJ9/TOehK82VvomQ6zFiZjPeSom8fLkFVLuYL3sKiIb5RB8iN/lenLkY7oBmyQcGP7FBMGiIZTO8jufaRQ==",
+            "requires": {
+                "@octokit/types": "^4.0.1",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "@octokit/types": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.0.2.tgz",
+            "integrity": "sha512-+4X6qfhT/fk/5FD66395NrFLxCzD6FsGlpPwfwvnukdyfYbhiZB/FJltiT1XM5Q63rGGBSf9FPaNV3WpNHm54A==",
+            "requires": {
+                "@types/node": ">= 8"
+            }
+        },
         "@sinonjs/formatio": {
             "version": "2.0.0",
             "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -12,6 +110,11 @@
             "requires": {
                 "samsam": "1.3.0"
             }
+        },
+        "@types/node": {
+            "version": "14.0.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
+            "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -918,6 +1021,11 @@
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
             "dev": true
+        },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "buffer-fill": {
             "version": "1.0.0",
@@ -1950,6 +2058,11 @@
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
             "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
         },
+        "deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -2094,6 +2207,14 @@
                 "jsbn": "~0.1.0"
             }
         },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2127,7 +2248,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -2500,6 +2620,39 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
             "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
             "dev": true
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
+            }
         },
         "exit": {
             "version": "0.1.2",
@@ -3757,6 +3910,14 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "requires": {
+                "pump": "^3.0.0"
+            }
         },
         "get-uri": {
             "version": "2.0.2",
@@ -5305,6 +5466,35 @@
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
+        "jsonwebtoken": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+            "requires": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^5.6.0"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
+            }
+        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5321,6 +5511,25 @@
             "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
             "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
             "dev": true
+        },
+        "jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
         },
         "kareem": {
             "version": "1.5.0",
@@ -5601,10 +5810,45 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
         },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
         "lodash.omit": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
             "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+        },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "lodash.set": {
             "version": "4.3.2",
@@ -6218,6 +6462,11 @@
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
             "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
         },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
         "nise": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
@@ -6247,6 +6496,11 @@
                     }
                 }
             }
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "node-gyp": {
             "version": "3.8.0",
@@ -6480,6 +6734,14 @@
             "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
             "dev": true
         },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -6702,6 +6964,11 @@
                 "os-tmpdir": "^1.0.0"
             }
         },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
         "pac-proxy-agent": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
@@ -6882,6 +7149,11 @@
             "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
             "version": "1.0.6",
@@ -7117,6 +7389,15 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
             "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA=="
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "punycode": {
             "version": "1.4.1",
@@ -7743,7 +8024,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -7751,8 +8031,7 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "shelljs": {
             "version": "0.3.0",
@@ -8748,6 +9027,11 @@
                 "is-utf8": "^0.2.0"
             }
         },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+        },
         "strip-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -9298,6 +9582,30 @@
                 "crypto-random-string": "^1.0.0"
             }
         },
+        "universal-user-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+            "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+            "requires": {
+                "os-name": "^3.1.0"
+            },
+            "dependencies": {
+                "macos-release": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+                    "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
+                },
+                "os-name": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+                    "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+                    "requires": {
+                        "macos-release": "^2.2.0",
+                        "windows-release": "^3.1.0"
+                    }
+                }
+            }
+        },
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9595,6 +9903,14 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
             "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+        },
+        "windows-release": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
+            "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
+            "requires": {
+                "execa": "^1.0.0"
+            }
         },
         "winston": {
             "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "bugs": "https://github.com/cla-assistant/cla-assistant/issues",
     "contributors": [],
     "dependencies": {
+        "@octokit/app": "^4.2.0",
+        "@octokit/request": "^5.4.4",
         "angular": "^1.7.0",
         "applicationinsights": "^1.0.0",
         "array-sugar": "^1.2.2",

--- a/src/config.js
+++ b/src/config.js
@@ -40,7 +40,11 @@ module.exports = {
             enforceDelay: parseInt(process.env.GITHUB_DELAY || '5000', 10),
 
             //slow down API calls in order to avoid abuse rate limit
-            timeToWait: process.env.GITHUB_TIME_TO_WAIT || 1000
+            timeToWait: process.env.GITHUB_TIME_TO_WAIT || 1000,
+
+            // GitHub App id
+            appId: parseInt(process.env.GITHUB_APP_ID, 10),
+            appPrivateKey: process.env.GITHUB_APP_PRIVATE_KEY
         },
 
         localport: process.env.PORT || 5000,

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -118,22 +118,14 @@ async function validatePR(args) {
         args.token = item.token;
         if (!item.gist) {
             await promisify(status.updateForNullCla.bind(status))(args);
-            await promisify(prService.deleteComment.bind(prService))({
-                repo: args.repo,
-                owner: args.owner,
-                number: args.number
-            });
+            await promisify(prService.deleteComment.bind(prService))(args);
 
             return;
         }
         const isClaRequired = await cla.isClaRequired(args);
         if (!isClaRequired) {
             await promisify(status.updateForClaNotRequired.bind(status))(args);
-            await promisify(prService.deleteComment.bind(prService))({
-                repo: args.repo,
-                owner: args.owner,
-                number: args.number
-            });
+            await promisify(prService.deleteComment.bind(prService))(args);
 
             return;
         }
@@ -154,7 +146,8 @@ async function validatePR(args) {
             owner: args.owner,
             number: args.number,
             signed: args.signed,
-            user_map: user_map
+            user_map: user_map,
+            token: args.token
         });
     } catch (e) {
         let logArgs = Object.assign({}, args, { user: undefined, userId: undefined, token: args.token && `${args.token.slice(0, 4)}***` });

--- a/src/server/services/installation.js
+++ b/src/server/services/installation.js
@@ -21,7 +21,7 @@ class Installation {
             const installationId = repo ? await this.getRepoInstallationId(repo, owner) : await this.getOrgInstallationId(owner);
             return await this.app.getInstallationAccessToken({ installationId });
         } catch (err) {
-            logger.trackEvent('Installation.getInstallationAccessToken.Failed', { repo, owner });
+            logger.trackEvent('Installation.getInstallationAccessToken.Failed', { repo, owner, msg: err.message });
             return;
         }
     }

--- a/src/server/services/installation.js
+++ b/src/server/services/installation.js
@@ -4,6 +4,8 @@ const logger = require('./logger');
 const memCache = require('memory-cache');
 const config = require('../../config');
 
+const aDay = 1000 * 60 * 60 * 24;
+
 class Installation {
 
     constructor(cache = memCache, app) {
@@ -19,7 +21,7 @@ class Installation {
             const installationId = repo ? await this.getRepoInstallationId(repo, owner) : await this.getOrgInstallationId(owner);
             return await this.app.getInstallationAccessToken({ installationId });
         } catch (err) {
-            logger.trackEvent('github.getInstallationAccessToken.Failed', { repo, owner });
+            logger.trackEvent('Installation.getInstallationAccessToken.Failed', { repo, owner });
             return;
         }
     }
@@ -39,7 +41,7 @@ class Installation {
                 accept: 'application/vnd.github.machine-man-preview+json',
             }
         });
-        cache.push(key, data.id);
+        this.cache.put(key, data.id, aDay);
         return data.id
     }
 
@@ -56,7 +58,7 @@ class Installation {
                 accept: 'application/vnd.github.machine-man-preview+json',
             }
         });
-        cache.push(org, data.id);
+        this.cache.put(org, data.id, aDay);
         return data.id
     }
 }

--- a/src/server/services/installation.js
+++ b/src/server/services/installation.js
@@ -22,7 +22,6 @@ class Installation {
             return await this.app.getInstallationAccessToken({ installationId });
         } catch (err) {
             logger.trackEvent('Installation.getInstallationAccessToken.Failed', { repo, owner, msg: err.message });
-            return;
         }
     }
 
@@ -42,7 +41,7 @@ class Installation {
             }
         });
         this.cache.put(key, data.id, aDay);
-        return data.id
+        return data.id;
     }
 
     async getOrgInstallationId(org) {
@@ -59,7 +58,7 @@ class Installation {
             }
         });
         this.cache.put(org, data.id, aDay);
-        return data.id
+        return data.id;
     }
 }
 

--- a/src/server/services/installation.js
+++ b/src/server/services/installation.js
@@ -1,0 +1,64 @@
+const App = require('@octokit/app').App;
+const request = require('@octokit/request').request;
+const logger = require('./logger');
+const memCache = require('memory-cache');
+const config = require('../../config');
+
+class Installation {
+
+    constructor(cache = memCache, app) {
+        this.cache = cache;
+        this.app = app || new App({
+            id: config.server.github.appId,
+            privateKey: config.server.github.appPrivateKey
+        });
+    }
+
+    async getInstallationAccessToken(repo, owner) {
+        try {
+            const installationId = repo ? await this.getRepoInstallationId(repo, owner) : await this.getOrgInstallationId(owner);
+            return await this.app.getInstallationAccessToken({ installationId });
+        } catch (err) {
+            logger.trackEvent('github.getInstallationAccessToken.Failed', { repo, owner });
+            return;
+        }
+    }
+
+    async getRepoInstallationId(repo, owner) {
+        const key = `${owner}/${repo}`;
+        const existing = this.cache.get(key);
+        if (existing) {
+            return existing;
+        }
+        const jwt = this.app.getSignedJsonWebToken();
+        const { data } = await request('GET /repos/:owner/:repo/installation', {
+            owner,
+            repo,
+            headers: {
+                authorization: `Bearer ${jwt}`,
+                accept: 'application/vnd.github.machine-man-preview+json',
+            }
+        });
+        cache.push(key, data.id);
+        return data.id
+    }
+
+    async getOrgInstallationId(org) {
+        const existing = this.cache.get(org);
+        if (existing) {
+            return existing;
+        }
+        const jwt = this.app.getSignedJsonWebToken();
+        const { data } = await request('GET /orgs/:org/installation', {
+            org,
+            headers: {
+                authorization: `Bearer ${jwt}`,
+                accept: 'application/vnd.github.machine-man-preview+json',
+            }
+        });
+        cache.push(org, data.id);
+        return data.id
+    }
+}
+
+module.exports = new Installation();

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -2,7 +2,6 @@ require('../documents/org');
 let mongoose = require('mongoose');
 let Org = mongoose.model('Org');
 let config = require('../../config');
-const github = require('./github');
 const installation = require('./installation');
 
 let selection = function (args) {

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -2,6 +2,8 @@ require('../documents/org');
 let mongoose = require('mongoose');
 let Org = mongoose.model('Org');
 let config = require('../../config');
+const github = require('./github');
+const installation = require('./installation');
 
 let selection = function (args) {
     let selectArguments = args.orgId ? { orgId: args.orgId } : { org: args.org };
@@ -56,12 +58,13 @@ module.exports = {
     },
 
     get: function (args, done) {
-        Org.findOne(selection(args), function (err, org) {
+        Org.findOne(selection(args), async function (err, org) {
             if (!err && !org) {
                 err = 'Organization not found in Database';
             }
-            if (org && config.server.github.adminToken) {
-                org.token = config.server.github.adminToken;
+            if (org) {
+                const installationToken = await installation.getInstallationAccessToken(args.repo, args.org);
+                org.token = installationToken || config.server.github.adminToken || org.token;
             }
             done(err, org);
         });

--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -50,7 +50,7 @@ let commentText = function (signed, badgeUrl, claUrl, user_map, recheckUrl) {
 // };
 
 module.exports = {
-    badgeComment: function (owner, repo, pullNumber, signed, user_map, done) {
+    badgeComment: function (owner, repo, pullNumber, signed, user_map, token, done) {
         let badgeUrl = url.pullRequestBadge(signed);
 
         // if (user_map && !commentNeeded(user_map)) {
@@ -60,7 +60,8 @@ module.exports = {
         this.getComment({
             repo: repo,
             owner: owner,
-            number: pullNumber
+            number: pullNumber,
+            token
         }, function (error, comment) {
             let claUrl = url.claURL(owner, repo, pullNumber);
             let recheckUrl = url.recheckPrUrl(owner, repo, pullNumber);
@@ -77,10 +78,7 @@ module.exports = {
                         body: body,
                         noCache: true
                     },
-                    basicAuth: {
-                        user: config.server.github.user,
-                        pass: config.server.github.pass
-                    }
+                    token,
                 }, function (e) {
                     if (e) {
                         log.error(new Error(e).stack);
@@ -98,10 +96,7 @@ module.exports = {
                         body: body,
                         noCache: true
                     },
-                    basicAuth: {
-                        user: config.server.github.user,
-                        pass: config.server.github.pass
-                    }
+                    token,
                 }, function (e) {
                     if (e) {
                         log.error(new Error(e).stack);
@@ -123,7 +118,7 @@ module.exports = {
                 number: args.number,
                 noCache: true
             },
-            token: config.server.github.token
+            token: args.token
         }, function (e, res) {
             let CLAAssistantComment;
             if (!e && res && !res.message) {
@@ -147,7 +142,8 @@ module.exports = {
         this.getComment({
             repo: args.repo,
             owner: args.owner,
-            number: args.number
+            number: args.number,
+            token: args.token
         }, function (error, comment) {
             if (error || !comment) {
                 return;
@@ -166,10 +162,7 @@ module.exports = {
                     body: body,
                     noCache: true
                 },
-                basicAuth: {
-                    user: config.server.github.user,
-                    pass: config.server.github.pass
-                }
+                token: args.token
             }, function (e) {
                 if (e) {
                     log.warn(new Error(e).stack);
@@ -186,7 +179,8 @@ module.exports = {
         this.getComment({
             repo: args.repo,
             owner: args.owner,
-            number: args.number
+            number: args.number,
+            token: args.token
         }, function (error, comment) {
             if (error) {
                 return log.warn(error, 'with args:', args.repo, args.owner, args.number);
@@ -202,10 +196,7 @@ module.exports = {
                     repo: args.repo,
                     id: comment.id
                 },
-                basicAuth: {
-                    user: config.server.github.user,
-                    pass: config.server.github.pass
-                }
+                token: args.token
             }, function (error) {
                 if (error) {
                     log.warn(error, 'with args:', { owner: args.owner, repo: args.repo, number: args.number, id: comment.id }, 'and commentId: ', comment.id);

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -70,7 +70,8 @@ async function updateStatusAndComment(args) {
             args.repo,
             args.number,
             signed,
-            user_map
+            user_map,
+            args.token
         );
         logger.trackEvent('CLAAssistantPullRequestCommentUpdateSuccess', { deliveryId: args.deliveryId });
     }
@@ -106,11 +107,7 @@ async function handleWebHook(args) {
         } else {
             logger.trackEvent('CLAAssistantPullRequestUpdateForClaNotRequiredStart', { deliveryId: args.deliveryId, isClaRequired });
             await promisify(status.updateForClaNotRequired.bind(status))(args);
-            await promisify(pullRequest.deleteComment.bind(pullRequest))({
-                repo: args.repo,
-                owner: args.owner,
-                number: args.number
-            });
+            await promisify(pullRequest.deleteComment.bind(pullRequest))(args);
             logger.trackEvent('CLAAssistantPullRequestDeleteCommentSuccess', { deliveryId: args.deliveryId });
         }
         collectMetrics(args.owner, args.repo, args.number, args.userId, startTime, args.signed, args.action, isClaRequired, args.deliveryId);

--- a/src/tests/server/services/repo.js
+++ b/src/tests/server/services/repo.js
@@ -501,6 +501,7 @@ describe('repo:getPRCommitters', function () {
             assert.equal(data.length, 2);
             assert.equal(data[0].name, 'octocat');
             assert.equal(orgService.get.calledWith({
+                org: arg.owner,
                 orgId: 1
             }), true);
             assert(Repo.findOne.called);


### PR DESCRIPTION
Integrate Github App.

Previously, CLA-Assistant uses the stored token to get PR, update comments, and status, which is not secure. After integrating to Github App, admins could install the app on orgs and repos. This gives the app corresponding permission. Then we just need to use the app's server-to-server token to get PR, update comments and status. 