### PR TITLE
GitHub will deprecate GET /applications/:client_id/tokens/:access_token

### DIFF
--- a/src/server/passports/github.js
+++ b/src/server/passports/github.js
@@ -1,11 +1,11 @@
 let url = require('../services/url');
 let repoService = require('../services/repo');
 let orgApi = require('../api/org');
-let github = require('../services/github');
 let logger = require('../services/logger');
 let passport = require('passport');
 let Strategy = require('passport-github').Strategy;
 let merge = require('merge');
+let { request } = require('@octokit/request');
 
 function updateToken(item, newToken) {
     item.token = newToken;
@@ -13,24 +13,25 @@ function updateToken(item, newToken) {
     logger.debug('Update access token for repo / org', item.repo || item.org);
 }
 
-function checkToken(item, accessToken) {
+async function checkToken(item, accessToken) {
     let newToken = accessToken;
     let oldToken = item.token;
-    let args = {
-        obj: 'authorization',
-        fun: 'check',
-        arg: {
-            access_token: oldToken,
-            client_id: config.server.github.client
-        },
-        basicAuth: {
-            user: config.server.github.client,
-            pass: config.server.github.secret
-        }
-    };
 
-    github.call(args, function (err, data) {
-        if (err || !(data && data.scopes && data.scopes.indexOf('write:repo_hook') >= 0)) {
+    try {
+        const response = await request('POST /applications/{client_id}/token', {
+            client_id: config.server.github.client,
+            access_token: oldToken,
+            headers: {
+                authorization: `Basic ${Buffer.from(`${config.server.github.client}:${config.server.github.secret}`, 'utf8').toString('base64')}`,
+                // accept: 'application/vnd.github.doctor-strange-preview+json'
+            }
+        });
+
+        if (!response || response.status !== 200) {
+            updateToken(item, newToken);
+        }
+        const { data } = response;
+        if (!data || !data.scopes || data.scopes.indexOf('write:repo_hook') == 0) {
             updateToken(item, newToken);
         } else if (item.repo) {
             repoService.getGHRepo(item, function (err, ghRepo) {
@@ -40,7 +41,10 @@ function checkToken(item, accessToken) {
                 }
             });
         }
-    });
+    } catch (err) {
+        logger.info(`Check token for ${item.repo} failed: ${err.message}`);
+        updateToken(item, newToken);
+    }
 }
 
 passport.use(new Strategy({

--- a/src/server/passports/github.js
+++ b/src/server/passports/github.js
@@ -23,7 +23,6 @@ async function checkToken(item, accessToken) {
             access_token: oldToken,
             headers: {
                 authorization: `Basic ${Buffer.from(`${config.server.github.client}:${config.server.github.secret}`, 'utf8').toString('base64')}`,
-                // accept: 'application/vnd.github.doctor-strange-preview+json'
             }
         });
 
@@ -31,7 +30,7 @@ async function checkToken(item, accessToken) {
             updateToken(item, newToken);
         }
         const { data } = response;
-        if (!data || !data.scopes || data.scopes.indexOf('write:repo_hook') == 0) {
+        if (!data || !data.scopes || data.scopes.indexOf('write:repo_hook') < 0) {
             updateToken(item, newToken);
         } else if (item.repo) {
             repoService.getGHRepo(item, function (err, ghRepo) {


### PR DESCRIPTION
Replace the above endpoint to POST /applications/:client_id/token.

Here is the docs https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/